### PR TITLE
RDS Performance Insights toggle and key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,8 @@ module "db" {
   db_cluster_parameter_group_name = var.rds_cluster_parameter_group_name == null ? element(aws_rds_cluster_parameter_group.db.*.name, 1) : var.rds_cluster_parameter_group_name
   allowed_cidr_blocks = var.allowed_cidr_blocks
   backup_retention_period = var.backup_retention_period
+  performance_insights_enabled = var.performance_insights_enabled
+  performance_insights_kms_key_id = var.performance_insights_kms_key_id
   preferred_backup_window = var.preferred_backup_window
   preferred_maintenance_window = var.preferred_maintenance_window
   deletion_protection = var.deletion_protection

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,18 @@ variable "backup_retention_period" {
   default     = 7
 }
 
+variable "performance_insights_enabled" {
+  description = "Whether or not to enable performance insights for this db."
+  type        = bool
+  default     = false
+}
+
+variable "performance_insights_kms_key_id" {
+  description = "The KMS key to use to encrypt Performance Insights data."
+  type        = string
+  default     = null
+}
+
 variable "preferred_backup_window" {
   description = "When to perform DB backups"
   type        = string


### PR DESCRIPTION
Adding performance insights parameter to toggle on/off, and reference to KMS key to use to encrypt performance insights data (same key used to encrypt the db). Plan shared separately. CDC-1851

